### PR TITLE
[AIE-23] Add AreaAttention Block

### DIFF
--- a/src/netspresso_trainer/models/op/base_metaformer.py
+++ b/src/netspresso_trainer/models/op/base_metaformer.py
@@ -477,3 +477,32 @@ class MetaFormer(nn.Module):
         x = self.norm(x)
         feat = torch.mean(x, dim=1)
         return BackboneOutput(last_feature=feat)
+
+
+# Efficient implementation equivalent to the following:
+def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+        is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+    L, S = query.size(-2), key.size(-2)
+    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
+    attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
+    if is_causal:
+        assert attn_mask is None
+        temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+        attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
+        attn_bias.to(query.dtype)
+
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.bool:
+            attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+        else:
+            attn_bias = attn_mask + attn_bias
+
+    if enable_gqa:
+        key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
+        value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
+
+    attn_weight = query @ key.transpose(-2, -1) * scale_factor
+    attn_weight += attn_bias
+    attn_weight = torch.softmax(attn_weight, dim=-1)
+    attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+    return attn_weight @ value

--- a/src/netspresso_trainer/models/op/base_metaformer.py
+++ b/src/netspresso_trainer/models/op/base_metaformer.py
@@ -477,33 +477,3 @@ class MetaFormer(nn.Module):
         x = self.norm(x)
         feat = torch.mean(x, dim=1)
         return BackboneOutput(last_feature=feat)
-
-
-# Efficient implementation equivalent to the following:
-# This implementation is from https://pytorch.org/docs/2.6/generated/torch.nn.functional.scaled_dot_product_attention.html#torch.nn.functional.scaled_dot_product_attention
-def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
-        is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
-    L, S = query.size(-2), key.size(-2)
-    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
-    attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
-    if is_causal:
-        assert attn_mask is None
-        temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
-        attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
-        attn_bias.to(query.dtype)
-
-    if attn_mask is not None:
-        if attn_mask.dtype == torch.bool:
-            attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
-        else:
-            attn_bias = attn_mask + attn_bias
-
-    if enable_gqa:
-        key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
-        value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
-
-    attn_weight = query @ key.transpose(-2, -1) * scale_factor
-    attn_weight += attn_bias
-    attn_weight = torch.softmax(attn_weight, dim=-1)
-    attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
-    return attn_weight @ value

--- a/src/netspresso_trainer/models/op/base_metaformer.py
+++ b/src/netspresso_trainer/models/op/base_metaformer.py
@@ -480,6 +480,7 @@ class MetaFormer(nn.Module):
 
 
 # Efficient implementation equivalent to the following:
+# This implementation is from https://pytorch.org/docs/2.6/generated/torch.nn.functional.scaled_dot_product_attention.html#torch.nn.functional.scaled_dot_product_attention
 def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
         is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
     L, S = query.size(-2), key.size(-2)

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -1306,3 +1306,34 @@ class Anchor2Vec(nn.Module):
         self.anchor2vec = self.anchor2vec.to(x.device)
         vector_x = self.anchor2vec(anchor_x.softmax(dim=1))[:, 0]
         return anchor_x, vector_x
+
+
+# Efficient implementation equivalent to the following:
+# This implementation is from https://pytorch.org/docs/2.6/generated/torch.nn.functional.scaled_dot_product_attention.html#torch.nn.functional.scaled_dot_product_attention
+def scaled_dot_product_attention(
+    query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False
+) -> torch.Tensor:
+    L, S = query.size(-2), key.size(-2)
+    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
+    attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
+    if is_causal:
+        assert attn_mask is None
+        temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+        attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
+        attn_bias.to(query.dtype)
+
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.bool:
+            attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+        else:
+            attn_bias = attn_mask + attn_bias
+
+    if enable_gqa:
+        key = key.repeat_interleave(query.size(-3) // key.size(-3), -3)
+        value = value.repeat_interleave(query.size(-3) // value.size(-3), -3)
+
+    attn_weight = query @ key.transpose(-2, -1) * scale_factor
+    attn_weight += attn_bias
+    attn_weight = torch.softmax(attn_weight, dim=-1)
+    attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+    return attn_weight @ value

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -1338,6 +1338,7 @@ def scaled_dot_product_attention(
     attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
     return attn_weight @ value
 
+
 class AreaAttention(nn.Module):
     def __init__(self, in_channels: int, num_heads: int, num_areas: int = 4):
         super().__init__()


### PR DESCRIPTION
## Description

This PR aims to add area attention block for future support of yolov12.


pytest results are following
```
collected 5 items                                                                                                                   

test_attention.py::TestAttention::test_scaled_dot_product_attention PASSED                                                    [ 20%]
test_attention.py::TestAttention::test_area_attention PASSED                                                                  [ 40%]
test_attention.py::TestAttention::test_scaled_dot_product_attention_different_sizes[1-1-64-32] PASSED                         [ 60%]
test_attention.py::TestAttention::test_scaled_dot_product_attention_different_sizes[16-4-256-64] PASSED                       [ 80%]
test_attention.py::TestAttention::test_scaled_dot_product_attention_different_sizes[32-8-128-64] PASSED                       [100%]
```
Closes: N/A

## Change(s)

- Add scaled_dot_product_attention_block
- Add AreaAttention block

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.